### PR TITLE
Enter the container as the root user

### DIFF
--- a/sandbox
+++ b/sandbox
@@ -102,7 +102,7 @@ sandbox () {
   # Enter attaches users to a shell in the desired container
   enter () {
     statusline "Entering /bin/bash session in the sandbox container..."
-    docker exec -w /opt/algorand/node -it sandbox /bin/bash
+    docker exec -w /opt/algorand/node -it --user="root" sandbox /bin/bash
   }
 
   # Logs streams the logs from the container to the shell


### PR DESCRIPTION
Currently, there is no user set when entering the container so it is entered as a nonexistent user. This means that the files inside the node directory are not editable.

The only change is the `--user="root"` flag when entering the container.

This was tested on macOS 10.15.1 and Ubuntu 18.04.