### PR TITLE
change use-snapshot to skip-snapshot to match docs

### DIFF
--- a/sandbox
+++ b/sandbox
@@ -330,7 +330,7 @@ EOF
 PARAMS=()
 while (( "$#" )); do
   case "$1" in
-    -s|--use-snapshot)
+    -s|--skip-snapshot)
       USE_SNAPSHOT=0
       shift
       ;;


### PR DESCRIPTION
`--use-snapshot` flag was skipping the snapshot download. The help message indicates that the flag should be `--skip-snapshot` so changed it to match the docs.
#6