### PR TITLE
Fix error when no parameter given

### DIFF
--- a/sandbox
+++ b/sandbox
@@ -342,5 +342,5 @@ while (( "$#" )); do
 done
 
 pushd `dirname $0` > /dev/null
-sandbox "${PARAMS[@]}"
+sandbox "${PARAMS[@]-}"
 popd > /dev/null


### PR DESCRIPTION
Small fix to remove the error:
```
./sandbox: line 345: PARAMS[@]: unbound variable
```
when `./sandbox` is called without any parameters.