### PR TITLE
Better error handling

### DIFF
--- a/sandbox
+++ b/sandbox
@@ -178,6 +178,13 @@ sandbox () {
       docker start sandbox > /dev/null || ERROR=1
 
       if [[ $ERROR -ne 0 ]]; then
+        # Check if the error is not just due to docker daemon not running
+        if ! docker info 2>/dev/null > /dev/null; then
+          err 'Docker is not running. Run `docker info` for more information.'
+          exit 1
+        fi
+
+        # This is another error that may require reset of the sandbox
         err "Detected an error from the docker command."
         if [[ $# -eq 0 ]]; then
           NETWORK=$(cat data/network)

--- a/sandbox
+++ b/sandbox
@@ -172,10 +172,12 @@ sandbox () {
     # Resume or initialize sandbox
     if [[ -d data ]]; then
       statusline "Starting the existing sandbox..."
-      set +e
-      docker start sandbox > /dev/null
+      # Use variable $ERROR instead of status $?
+      # as we are using set -e which aborts in case of non-zero status
+      ERROR=0
+      docker start sandbox > /dev/null || ERROR=1
 
-      if [[ $? -ne 0 ]]; then
+      if [[ $ERROR -ne 0 ]]; then
         err "Detected an error from the docker command."
         if [[ $# -eq 0 ]]; then
           NETWORK=$(cat data/network)
@@ -184,7 +186,6 @@ sandbox () {
         statusline "Starting '$NETWORK' sandbox..."
         up $NETWORK
       fi
-      set -e
     else
       statusline "\nBuilding a new Docker Image..."
       docker build \


### PR DESCRIPTION
1. Do not ignore error if the data folder is corrupted. This should probably solve the problem in issue #9 
2. Test if Docker running before asking to reset sandbox to avoid having users resetting sandbox before realizing that the issue was that Docker was not running.