### PR TITLE
removing duped log flag

### DIFF
--- a/images/indexer/start.sh
+++ b/images/indexer/start.sh
@@ -55,7 +55,6 @@ import_and_start_readonly() {
     --dev-mode \
     --server ":$PORT" \
     -P "$CONNECTION_STRING" \
-    --logfile "/tmp/indexer-log.txt"
     --logfile "/tmp/indexer-log.txt" >> /tmp/command.txt
 }
 


### PR DESCRIPTION
log flag listed twice, and first time no \ so i think it'd just execute the command and not redirect output to /tmp/command.txt but i did not test it