### PR TITLE
Add generic Exec command

### DIFF
--- a/sandbox
+++ b/sandbox
@@ -554,7 +554,10 @@ EOF
       shift
       docker cp "$1" "$(dc ps -q algod):/opt/data/$1"
       ;;
-
+    exec)
+      shift
+      docker exec -it "$(dc ps -q algod)" sh -c "$@"
+      ;;
     *)
       help
       ;;


### PR DESCRIPTION
Idk if this is bad practice or anything but useful for something like:

`./sandbox exec "cat first.txn second.txn third.txn > combined.txn"`

to be later grouped with goal