### PR TITLE
Allow sandbox copy to accept file in subdirectory

### DIFF
--- a/sandbox
+++ b/sandbox
@@ -556,7 +556,7 @@ EOF
 
     copy|cp)
       shift
-      docker cp "$1" "$(dc ps -q algod):/opt/data/$1"
+      docker cp "$1" "$(dc ps -q algod):/opt/data/$(basename $1)"
       ;;
 
     *)


### PR DESCRIPTION
Small change to allow files to be copied in from subdirectories, and even from outside of the sandbox root directory. `basename` should be available on all unix-like environments

example: 
- `./sandbox copy contracts/example.teal`
- `./sandbox copy /home/contracts/example.teal`