### PR TITLE
starting point

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,11 @@ version: '3'
 services:
   algod:
     container_name: "algorand-sandbox-algod"
+    environment: 
+      - ALGOD_CHANNEL=${ALGOD_CHANNEL}
+      - ALGOD_BRANCH=${ALGOD_BRANCH}
+      - ALGOD_URL=${ALGOD_URL}
+      - INSTALL_SCRIPT_DIR=/tmp/images/algod
     build:
       context: .
       dockerfile: ./images/algod/Dockerfile
@@ -17,6 +22,7 @@ services:
         TOKEN: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         ALGOD_PORT: "4001"
         KMD_PORT: "4002"
+    command: sh -c "/tmp/images/algod/monitor.sh"
     ports:
       - 4001:4001
       - 4002:4002

--- a/images/algod/monitor.sh
+++ b/images/algod/monitor.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Script to handle automatic updating before container startup
+#
+# No Parameters
+
+# exit 1
+
+set -e
+
+if [ ! -z ALGOD_CHANNEL ] && [ ! -z INSTALL_SCRIPT_DIR ]; then
+  [ "${INSTALL_SCRIPT_DIR}/install.sh -d ${BIN_DIR} -c ${ALGOD_CHANNEL}" ]
+  echo $?
+elif [ ! -z ALGOD_BRANCH ] && [ ! -z ALGOD_URL ] && [ ! -z INSTALL_SCRIPT_DIR ]; then
+  [ "${INSTALL_SCRIPT_DIR}/install.sh -d ${BIN_DIR} -b ${ALGOD_BRANCH} -u ${ALGOD_URL} " ]
+  echo $?
+fi
+
+/opt/start_algod.sh


### PR DESCRIPTION
This is my starting point for solving Issue #41. This is just for the algod container, but I'm thinking of using a similar approach with the indexer container

The logic is as follows:

1. From root repository directory, user calls `./sandbox up [some_release_channel]`
2. Inside of the `up` function, `docker-compose` is called, using the new configuration in `docker-compose.yml`
3. The new configuration replaces the Dockerfile entrypoint command with `sh -c "/tmp/images/algod/monitor.sh"`
4. The new script `monitor.sh` determines if it should update using a **release channel** or a **branch**

I'll also need to include some way to only automatically update if the user uses [some_release_channel] in step 1. I'm thinking of setting an env variable `$INIT_COMMAND` that is equal to:

- `$INIT_COMMAND="sh -c "/tmp/images/algod/monitor.sh""` if [some_release_channel] is used in step 1
- `$INIT_COMMAND="sh -c "/opt/start_algod.sh""` if user just calls `./sandbox up` in step 1

I'd love to hear your thoughts.