### PR TITLE
Add Support for Automatic Updates Using `./sandbox up [config]`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
         TOKEN: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         ALGOD_PORT: "4001"
         KMD_PORT: "4002"
+    environment:
+      UPDATE_TRIGGER: "${UPDATE_TRIGGER}"
     ports:
       - 4001:4001
       - 4002:4002
@@ -40,6 +42,7 @@ services:
       CONNECTION_STRING: "host=indexer-db port=5432 user=algorand password=algorand dbname=indexer_db sslmode=disable"
       ALGOD_ADDR: "algod:4001"
       ALGOD_TOKEN: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      UPDATE_TRIGGER: "${UPDATE_TRIGGER}"
     depends_on:
       - indexer-db
       - algod

--- a/images/algod/Dockerfile
+++ b/images/algod/Dockerfile
@@ -15,6 +15,9 @@ ARG KMD_PORT=""
 ARG TOKEN=""
 ARG TEMPLATE=""
 
+# Trigger variables for launch script
+ENV UPDATE_TRIGGER="${UPDATE_TRIGGER}"
+
 RUN echo "Installing from source. ${URL} -- ${BRANCH}"
 ENV BIN_DIR="$HOME/node"
 ENV ALGORAND_DATA="/opt/data"
@@ -53,4 +56,4 @@ ENV PATH="$BIN_DIR:${PATH}"
 WORKDIR /opt/data
 
 # Start algod
-CMD ["/opt/start_algod.sh"]
+CMD ["/tmp/images/algod/launch.sh"]

--- a/images/algod/launch.sh
+++ b/images/algod/launch.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Script automatically check and install any updates on the
+# current release channel for the algod node
+#
+# No parameters
+
+echo "Launch Script called"
+
+if [ ! -z "$UPDATE_TRIGGER" ]; then
+  UPDATE_TRIGGER=""
+  /bin/bash /tmp/images/algod/update.sh -d /opt/data -p /node
+fi
+
+/bin/bash /opt/start_algod.sh

--- a/images/indexer/Dockerfile
+++ b/images/indexer/Dockerfile
@@ -5,6 +5,9 @@ ARG URL=https://github.com/algorand/indexer
 ARG BRANCH=master
 ARG SHA=""
 
+# Trigger variables for launch script
+ENV UPDATE_TRIGGER="${UPDATE_TRIGGER}"
+
 ENV HOME /opt/indexer
 WORKDIR /opt/indexer
 
@@ -15,8 +18,9 @@ RUN apk add --no-cache git bzip2 make bash
 COPY images/indexer/disabled.go /tmp/disabled.go
 COPY images/indexer/start.sh /tmp/start.sh
 COPY images/indexer/install.sh /tmp/install.sh
+COPY images/indexer/launch.sh /tmp/launch.sh
 
 # Install indexer binaries.
 RUN /tmp/install.sh
 
-CMD ["/tmp/start.sh"]
+CMD ["/tmp/launch.sh"]

--- a/images/indexer/launch.sh
+++ b/images/indexer/launch.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+echo "Launch script called"
+
+set -e
+
+if [ ! -z "$UPDATE_TRIGGER" ]; then
+  UPDATE_TRIGGER=""
+
+  cd /opt/indexer
+  git pull
+  make
+  cp cmd/algorand-indexer/algorand-indexer /tmp
+else
+  echo "No update triggered"
+fi
+
+/tmp/start.sh

--- a/sandbox
+++ b/sandbox
@@ -30,6 +30,11 @@ export INDEXER_BRANCH=""
 export INDEXER_SHA=""
 export INDEXER_DISABLED=""
 
+###################
+# TRIGGER VARIABLES
+###################
+export UPDATE_TRIGGER=""
+
 #########################
 # Helpers and utilities #
 #########################
@@ -52,6 +57,10 @@ function printc () {
 
 function statusline () {
   printc "${Bgreen}" "\n$1"
+}
+
+function progressline () {
+  printc "${teal}" "$1"
 }
 
 function err_noexit () {
@@ -157,12 +166,21 @@ function progress_bar {
   overwrite "$1 : [${fill// /▇}${empty// / }] [$2/$3] ${progress}%"
 }
 
+function get_health () {
+  # https://stackoverflow.com/questions/12321469/
+  # Retry a Bash command with timeout
+  #   petertc
+  timeout 15s bash -c 'until curl -s "localhost:8980/health?pretty"; do echo -n " . " & sleep 1; done'
+}
+
 sandbox () {
   status_helper () {
     statusline "algod - goal node status"
     goal_helper node status
+
     statusline "indexer - health"
-    curl -s "localhost:8980/health?pretty"
+    progressline "Waiting on reponse from algod ."
+    get_health
   }
 
   dc () {
@@ -177,7 +195,7 @@ sandbox () {
     statusline "algod version"
     dc exec algod goal -v
     statusline "Indexer version"
-    INDEXER_VERSION=$(dc exec indexer cmd/algorand-indexer/algorand-indexer -v) && echo ${INDEXER_VERSION} || curl -s "localhost:8980/health?pretty"
+    INDEXER_VERSION=$(dc exec indexer cmd/algorand-indexer/algorand-indexer -v) && echo ${INDEXER_VERSION} || get_health
     statusline "Postgres version"
     dc exec indexer-db postgres --version
   }
@@ -331,6 +349,7 @@ sandbox () {
         ACTIVE_CONFIG=$(cat $ACTIVE_CONFIG_FILE)
       fi
 
+      echo "$1"
       # Initialize new config, accounting for no-argument up command.
       if [ "$1" = "" ]; then
         if [ ! -z $ACTIVE_CONFIG ]; then
@@ -342,6 +361,7 @@ sandbox () {
           NEW_CONFIG="$DEFAULT_CONFIG"
         fi
       else
+        UPDATE_TRIGGER="$1"
         statusline "Starting sandbox for: $1"
         NEW_CONFIG="$1"
       fi
@@ -370,18 +390,30 @@ sandbox () {
       echo "$NEW_CONFIG" > "$ACTIVE_CONFIG_FILE"
       source "$CONFIG_FILE"
       if [ $INTERACTIVE_MODE == 1 ]; then
-        dc up
+        if [ "$1" -ne "" ]; then
+          dc up
+        else
+          dc up
+        fi
       elif [ $VERBOSE_MODE == 0 ]; then
         echo "see sandbox.log for detailed progress, or use -v."
         echo "* docker-compose up -d"   >> "$SANDBOX_LOG"
         echo "" # The spinner will rewrite this line.
-        dc up -d                        >> "$SANDBOX_LOG" 2>&1 & spinner
+        if [ "$1" -ne "" ]; then
+          dc up -d                        >> "$SANDBOX_LOG" 2>&1 & spinner
+        else
+          dc up -d                        >> "$SANDBOX_LOG" 2>&1 & spinner
+        fi
         sleep 1                                                & spinner
         overwrite "* started!"
       else
         echo "* docker-compose up -d"
         echo "" # The spinner will rewrite this line.
-        dc up -d
+        if [ "$1" -ne "" ]; then
+          dc up -d
+        else
+          dc up -d
+        fi
         sleep 1
       fi
 


### PR DESCRIPTION
So as requested in Issue #41 by @winder, I've made it so that when you use `./sandbox up [config]`, your containers are automatically updated.

#### For Example
Say you have an existing sandbox using the **nightly** channel configuration. If you become aware that the contributors at `algorand/sandbox` have released a new stable version, you no longer have to enter the sandbox and make changes yourself (A problem brought up by @ryanRfox. As suggested by @winder, if you would like to upgrade at sandbox startup, simply add a configuration parameter to your up command like so:

`./sandbox up nightly`

#### The solution
`docker-compose` allows you to set environment variables for images, even after they've been built. Using this knowledge, I created an environment variable `$UPDATE_TRIGGER` that gets in the `up` function of the `sandbox` script. This variable is empty if there is no [config] parameter, but it takes on the value of the [config] if the parameter is passed as shown in the example above.

Once the container recognizes the $UPDATE_TRIGGER env variable is **non-empty**, it will update from the release channel or from source.

#### Testing
So far, I've tested the code on:

- [x] Windows 10 (git bash and WSL2 running Ubuntu 18.04)
- [ ] Ubuntu Linux 20.04 LTS
- [ ] Max OSX

#### User-Facing Documentation
As you can probably tell from this message, I've already put some thought into how I'll explain this change in the README.md. However, I think we should include that in a separate PR.