### PR TITLE
Fixed Postgres Deployment and Status Problem

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,6 @@ services:
     container_name: "algorand-sandbox-postgres"
     ports:
       - 5433:5432
-    # https://stackoverflow.com/questions/28311825/root-execution-of-the-postgresql-server-is-not-permitted
     user: postgres
     environment:
       POSTGRES_USER: algorand

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,8 @@ services:
     container_name: "algorand-sandbox-postgres"
     ports:
       - 5433:5432
+    # https://stackoverflow.com/questions/28311825/root-execution-of-the-postgresql-server-is-not-permitted
+    user: postgres
     environment:
       POSTGRES_USER: algorand
       POSTGRES_PASSWORD: algorand

--- a/sandbox
+++ b/sandbox
@@ -191,7 +191,7 @@ sandbox () {
     statusline "Indexer version"
     INDEXER_VERSION=$(dc exec indexer cmd/algorand-indexer/algorand-indexer -v) && echo ${INDEXER_VERSION} || curl -s "localhost:8980/health?pretty"
     statusline "Postgres version"
-    dc exec indexer-db postgres --version
+    dc exec indexer-db postgres -V
   }
 
   # Given a network name attempts to fetch a catchpoint and catchup.
@@ -577,7 +577,7 @@ EOF
 
     copyFrom|cpf)
       shift
-      docker cp "$(dc ps -q algod):/opt/data/$(basename $1)" "$1" 
+      docker cp "$(dc ps -q algod):/opt/data/$(basename $1)" "$1"
       ;;
 
     *)


### PR DESCRIPTION
1. When running `./sandbox up -v`, the console will show the following message when deploying Postgres:

```
"root" execution of the PostgreSQL server is not permitted.
The server must be started under an unprivileged user ID to prevent
possible system security compromise.  See the documentation for
more information on how to properly start the server.
```

Referencing this [link](https://stackoverflow.com/questions/58258624/initialize-postgres-container-from-docker-compose-file), the `docker-compose.yml` is changed.

2. When running `./sandbox status`, we can also see at the console that it fails to query the Postgres version, so the associated command is changed.

The `user` property for postgresql in the `docker-compose.yml` is added based upon this [link](https://stackoverflow.com/questions/28311825/root-execution-of-the-postgresql-server-is-not-permitted)