### PR TITLE
deprecate Trusty add Focal to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,132 +6,107 @@ jobs:
       dist: focal
       arch: amd64
       env : CONFIG=
-    - # same stage, parallel job
-      os: linux
+    - os: linux
       dist: focal
       arch: amd64
       env : CONFIG=betanet
-    - # same stage, parallel job
-      os: linux
+    - os: linux
       dist: focal
       arch: amd64
       env : CONFIG=testnet
-    - # same stage, parallel job
-      os: linux
+    - os: linux
       dist: focal
       arch: amd64
       env : CONFIG=devnet
-    - # same stage, parallel job
-      os: linux
+    - os: linux
       dist: focal
       arch: amd64
       env : CONFIG=dev
-    - # same stage, parallel job
-      os: linux
+    - os: linux
       dist: focal
       arch: amd64
       env : CONFIG=beta
-    - # same stage, parallel job
-      os: linux
+    - os: linux
       dist: focal
       arch: amd64
       env : CONFIG=release
-    - # same stage, parallel job
-      os: linux
+    - os: linux
       dist: focal
       arch: amd64
       env : CONFIG=nightly
 
     # Bionic
-    - # same stage, parallel job
-      os: linux
+    - os: linux
       dist: bionic
       arch: amd64
       env : CONFIG=
-      #    - # same stage, parallel job
-      #      os: linux
+      #    - #      os: linux
       #      dist: bionic
       #      arch: amd64
       #      env : CONFIG=mainnet
-    - # same stage, parallel job
-      os: linux
+    - os: linux
       dist: bionic
       arch: amd64
       env : CONFIG=betanet
-    - # same stage, parallel job
-      os: linux
+    - os: linux
       dist: bionic
       arch: amd64
       env : CONFIG=testnet
-    - # same stage, parallel job
-      os: linux
+    - os: linux
       dist: bionic
       arch: amd64
       env : CONFIG=devnet
-    - # same stage, parallel job
-      os: linux
+    - os: linux
       dist: bionic
       arch: amd64
       env : CONFIG=dev
-    - # same stage, parallel job
-      os: linux
+    - os: linux
       dist: bionic
       arch: amd64
       env : CONFIG=beta
-    - # same stage, parallel job
-      os: linux
+    - os: linux
       dist: bionic
       arch: amd64
       env : CONFIG=release
-    - # same stage, parallel job
-      os: linux
+    - os: linux
       dist: bionic
       arch: amd64
       env : CONFIG=nightly
 
     # Xenial
-    - # same stage, parallel job
-      os: linux
+    - os: linux
       dist: xenial
       arch: amd64
       env : CONFIG=
-      #    - # same stage, parallel job
-      #      os: linux
+      #    - #      os: linux
       #      dist: xenial
       #      arch: amd64
       #      env : CONFIG=mainnet
-    - # same stage, parallel job
-      os: linux
+    - os: linux
       dist: xenial
       arch: amd64
       env : CONFIG=betanet
-    - # same stage, parallel job
-      os: linux
+    - os: linux
       dist: xenial
       arch: amd64
       env : CONFIG=testnet
-    - # same stage, parallel job
-      os: linux
+    - os: linux
       dist: xenial
       arch: amd64
       env : CONFIG=devnet
-    - # same stage, parallel job
-      os: linux
+    - os: linux
       dist: xenial
       arch: amd64
       env : CONFIG=dev
-    - # same stage, parallel job
-      os: linux
+    - os: linux
       dist: xenial
       arch: amd64
       env : CONFIG=beta
-    - # same stage, parallel job
-      os: linux
+    - os: linux
       dist: xenial
       arch: amd64
       env : CONFIG=release
-    - # same stage, parallel job
-      os: linux
+    - os: linux
       dist: xenial
       arch: amd64
       env : CONFIG=nightly


### PR DESCRIPTION
## Summary
Trusty builds on Travis has been failing consistently. Since Trusty is a deprecated distribution with no support since Sept 30th, 2019, we will replace the Travis test with Focal which is the latest ubuntu dist. 

This should help give us better indication on whether or not new PRs or commits are actually failing.
Also this PR changes the stages into parallel jobs in Travis.

## Test
Create a draft PR and check if the Travis tests consistently pass.