### PR TITLE
Fix algod and indexer compilation issues

### DIFF
--- a/images/algod/Dockerfile
+++ b/images/algod/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14.7
+FROM golang:1.14.15
 
 ARG CHANNEL=nightly
 ARG URL=
@@ -23,7 +23,7 @@ ENV ALGORAND_DATA="/opt/data"
 # Basic dependencies.
 ENV HOME /opt
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install -y apt-utils curl git git-core bsdmainutils python3
+RUN apt-get update && apt-get install -y apt-utils curl git git-core bsdmainutils python3 libtool
 
 # Copy lots of things into the container. The gitignore indicates which directories.
 COPY . /tmp

--- a/images/indexer/Dockerfile
+++ b/images/indexer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.12-alpine
+FROM golang:1.14.15
 
 # Environment variables used by install.sh
 ARG URL=https://github.com/algorand/indexer
@@ -8,8 +8,9 @@ ARG SHA=""
 ENV HOME /opt/indexer
 WORKDIR /opt/indexer
 
+# Basic dependencies.
 ENV DEBIAN_FRONTEND noninteractive
-RUN apk add --no-cache git bzip2 make bash
+RUN apt-get update && apt-get install -y apt-utils curl git git-core bsdmainutils python3 libtool libboost-math-dev
 
 # Copy files to container.
 COPY images/indexer/disabled.go /tmp/disabled.go


### PR DESCRIPTION
Switch to Ubuntu (instead of alpine) for indexer and add missing dependencies.

Indexer failed to build because it now requires `go-algorand` that requires `libtool`

Concretely, when doing `./sandbox up nighlyt -v`, we get the following error:
```
Building indexer
[+] Building 12.3s (11/11) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                  0.0s
 => => transferring dockerfile: 550B                                                                                                                  0.0s
 => [internal] load .dockerignore                                                                                                                     0.0s
 => => transferring context: 34B                                                                                                                      0.0s
 => [internal] load metadata for docker.io/library/golang:1.13.12-alpine                                                                              0.2s
 => [internal] load build context                                                                                                                     0.0s
 => => transferring context: 196B                                                                                                                     0.0s
 => [1/7] FROM docker.io/library/golang:1.13.12-alpine@sha256:4c475018cc22a3c1b1e42806467be68c61beef9f94cb4533960f5fdd53f631b4                        0.0s
 => CACHED [2/7] WORKDIR /opt/indexer                                                                                                                 0.0s
 => [3/7] RUN apk add --no-cache git bzip2 make bash                                                                                                  1.1s
 => [4/7] COPY images/indexer/disabled.go /tmp/disabled.go                                                                                            0.0s
 => [5/7] COPY images/indexer/start.sh /tmp/start.sh                                                                                                  0.0s
 => [6/7] COPY images/indexer/install.sh /tmp/install.sh                                                                                              0.0s
 => ERROR [7/7] RUN /tmp/install.sh                                                                                                                  10.9s
------
 > [7/7] RUN /tmp/install.sh:
#11 0.188 Cloning into '/opt/indexer'...
#11 1.205 git submodule update --init && cd third_party/go-algorand && \
#11 1.205       make crypto/libs/`scripts/ostype.sh`/`scripts/archtype.sh`/lib/libsodium.a
#11 1.232 Submodule 'go-algorand' (https://github.com/algorand/go-algorand) registered for path 'third_party/go-algorand'
#11 1.235 Cloning into '/opt/indexer/third_party/go-algorand'...
#11 6.710 Submodule path 'third_party/go-algorand': checked out 'f72764b145ed50c01b29a93cf99bd6075e27f5d1'
#11 6.716 make[1]: Entering directory '/opt/indexer/third_party/go-algorand'
#11 6.893 env: can't execute 'python3': No such file or directory
#11 7.433 go: downloading github.com/getkin/kin-openapi v0.22.0
#11 7.435 go: downloading github.com/algorand/msgp v1.1.48
#11 7.437 go: downloading github.com/labstack/echo/v4 v4.1.17
#11 7.439 go: downloading github.com/algorand/websocket v1.4.3
#11 7.441 go: downloading golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
#11 7.441 go: downloading github.com/algorand/oapi-codegen v1.3.5-algorand5
#11 7.442 go: downloading github.com/algorand/go-codec v1.1.2
#11 7.443 go: downloading github.com/spf13/cobra v0.0.3
#11 7.459 go: downloading github.com/fatih/color v1.7.0
#11 7.491 go: extracting github.com/algorand/websocket v1.4.3
#11 7.498 go: extracting github.com/getkin/kin-openapi v0.22.0
#11 7.502 go: extracting github.com/algorand/msgp v1.1.48
#11 7.503 go: extracting github.com/algorand/go-codec v1.1.2
#11 7.504 go: downloading github.com/algorand/go-codec/codec v0.0.0-20190507210007-269d70b6135d
#11 7.507 go: downloading golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c
#11 7.525 go: downloading github.com/gen2brain/beeep v0.0.0-20180718162406-4e430518395f
#11 7.531 go: extracting github.com/algorand/oapi-codegen v1.3.5-algorand5
#11 7.536 go: extracting github.com/spf13/cobra v0.0.3
#11 7.536 go: extracting github.com/labstack/echo/v4 v4.1.17
#11 7.550 go: downloading github.com/satori/go.uuid v1.2.0
#11 7.551 go: downloading github.com/gorilla/mux v1.6.2
#11 7.551 go: downloading github.com/sirupsen/logrus v1.4.2
#11 7.554 go: downloading golang.org/x/net v0.0.0-20200904194848-62affa334b73
#11 7.563 go: extracting github.com/fatih/color v1.7.0
#11 7.565 go: downloading github.com/aws/aws-sdk-go v1.16.5
#11 7.572 go: downloading gopkg.in/yaml.v2 v2.3.0
#11 7.658 go: extracting github.com/gen2brain/beeep v0.0.0-20180718162406-4e430518395f
#11 7.665 go: downloading github.com/spf13/pflag v1.0.5
#11 7.670 go: extracting github.com/algorand/go-codec/codec v0.0.0-20190507210007-269d70b6135d
#11 7.691 go: extracting github.com/satori/go.uuid v1.2.0
#11 7.696 go: downloading github.com/google/go-querystring v1.0.0
#11 7.698 go: downloading github.com/godbus/dbus v0.0.0-20181101234600-2ff6f7ffd60f
#11 7.704 go: extracting github.com/gorilla/mux v1.6.2
#11 7.713 go: downloading github.com/labstack/gommon v0.3.0
#11 7.719 go: extracting github.com/sirupsen/logrus v1.4.2
#11 7.728 go: downloading gopkg.in/sohlich/elogrus.v3 v3.0.0-20180410122755-1fa29e2f2009
#11 7.730 go: extracting golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
#11 7.785 go: extracting gopkg.in/yaml.v2 v2.3.0
#11 7.797 go: extracting github.com/google/go-querystring v1.0.0
#11 7.799 go: downloading github.com/algorand/go-deadlock v0.2.1
#11 7.811 go: extracting gopkg.in/sohlich/elogrus.v3 v3.0.0-20180410122755-1fa29e2f2009
#11 7.815 go: extracting github.com/spf13/pflag v1.0.5
#11 7.816 go: extracting golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c
#11 7.817 go: extracting github.com/godbus/dbus v0.0.0-20181101234600-2ff6f7ffd60f
#11 7.818 go: extracting github.com/labstack/gommon v0.3.0
#11 7.819 go: extracting github.com/algorand/go-deadlock v0.2.1
#11 7.823 go: downloading github.com/valyala/fasttemplate v1.2.1
#11 7.831 go: downloading github.com/mattn/go-colorable v0.1.7
#11 7.843 go: extracting github.com/valyala/fasttemplate v1.2.1
#11 7.846 go: downloading github.com/cpuguy83/go-md2man v1.0.8
#11 7.850 go: extracting github.com/mattn/go-colorable v0.1.7
#11 7.854 go: downloading github.com/dchest/siphash v1.2.1
#11 7.868 go: extracting github.com/cpuguy83/go-md2man v1.0.8
#11 7.871 go: downloading github.com/olivere/elastic v6.2.14+incompatible
#11 7.877 go: extracting github.com/dchest/siphash v1.2.1
#11 7.879 go: downloading github.com/ghodss/yaml v1.0.0
#11 7.890 go: extracting golang.org/x/net v0.0.0-20200904194848-62affa334b73
#11 7.916 go: extracting github.com/ghodss/yaml v1.0.0
#11 7.917 go: downloading github.com/stretchr/testify v1.6.1
#11 7.953 go: extracting github.com/stretchr/testify v1.6.1
#11 7.954 go: extracting github.com/olivere/elastic v6.2.14+incompatible
#11 7.962 go: downloading github.com/valyala/bytebufferpool v1.0.0
#11 7.978 go: extracting github.com/valyala/bytebufferpool v1.0.0
#11 7.992 go: downloading github.com/mattn/go-isatty v0.0.12
#11 7.992 go: downloading github.com/jmoiron/sqlx v1.2.0
#11 7.993 go: downloading github.com/davidlazar/go-crypto v0.0.0-20170701192655-dcfb0a7ac018
#11 7.994 go: downloading golang.org/x/text v0.3.3
#11 8.010 go: extracting github.com/mattn/go-isatty v0.0.12
#11 8.013 go: downloading github.com/gofrs/flock v0.7.0
#11 8.019 go: extracting github.com/jmoiron/sqlx v1.2.0
#11 8.029 go: extracting github.com/davidlazar/go-crypto v0.0.0-20170701192655-dcfb0a7ac018
#11 8.033 go: downloading github.com/karalabe/hid v1.0.0
#11 8.040 go: downloading github.com/dgrijalva/jwt-go v3.2.0+incompatible
#11 8.287 go: extracting github.com/gofrs/flock v0.7.0
#11 8.289 go: downloading github.com/pmezard/go-difflib v1.0.0
#11 8.375 go: extracting github.com/dgrijalva/jwt-go v3.2.0+incompatible
#11 8.391 go: downloading github.com/davecgh/go-spew v1.1.1
#11 8.405 go: extracting github.com/karalabe/hid v1.0.0
#11 8.419 go: downloading github.com/pkg/errors v0.9.1
#11 8.601 go: extracting github.com/pkg/errors v0.9.1
#11 8.603 go: extracting github.com/pmezard/go-difflib v1.0.0
#11 8.606 go: extracting github.com/davecgh/go-spew v1.1.1
#11 8.607 go: downloading github.com/mattn/go-sqlite3 v1.10.0
#11 8.610 go: downloading gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
#11 8.638 go: extracting gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
#11 8.646 go: downloading github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5
#11 8.663 go: extracting github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5
#11 8.666 go: downloading github.com/mailru/easyjson v0.7.7
#11 8.697 go: extracting github.com/mailru/easyjson v0.7.7
#11 8.707 go: downloading github.com/josharian/intern v1.0.0
#11 8.847 go: extracting github.com/josharian/intern v1.0.0
#11 8.931 go: extracting golang.org/x/text v0.3.3
#11 8.940 go: extracting github.com/mattn/go-sqlite3 v1.10.0
#11 9.023 go: downloading github.com/miekg/dns v1.1.27
#11 9.067 go: extracting github.com/miekg/dns v1.1.27
#11 9.093 go: downloading github.com/russross/blackfriday v1.5.2
#11 9.121 go: extracting github.com/russross/blackfriday v1.5.2
#11 9.321 go: extracting github.com/aws/aws-sdk-go v1.16.5
#11 9.893 go: downloading github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
#11 9.957 go: extracting github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
#11 10.02 go: finding github.com/spf13/cobra v0.0.3
#11 10.03 go: finding github.com/algorand/go-codec/codec v0.0.0-20190507210007-269d70b6135d
#11 10.03 go: finding github.com/algorand/go-deadlock v0.2.1
#11 10.04 go: finding github.com/algorand/msgp v1.1.48
#11 10.05 go: finding github.com/stretchr/testify v1.6.1
#11 10.05 go: finding github.com/spf13/pflag v1.0.5
#11 10.06 go: finding github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5
#11 10.06 go: finding github.com/labstack/echo/v4 v4.1.17
#11 10.07 go: finding github.com/algorand/oapi-codegen v1.3.5-algorand5
#11 10.07 go: finding github.com/gofrs/flock v0.7.0
#11 10.07 go: finding github.com/mattn/go-sqlite3 v1.10.0
#11 10.08 go: finding github.com/getkin/kin-openapi v0.22.0
#11 10.08 go: finding golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
#11 10.09 go: finding github.com/cpuguy83/go-md2man v1.0.8
#11 10.09 go: finding github.com/davidlazar/go-crypto v0.0.0-20170701192655-dcfb0a7ac018
#11 10.09 go: finding github.com/olivere/elastic v6.2.14+incompatible
#11 10.10 go: finding github.com/satori/go.uuid v1.2.0
#11 10.10 go: finding github.com/sirupsen/logrus v1.4.2
#11 10.11 go: finding gopkg.in/sohlich/elogrus.v3 v3.0.0-20180410122755-1fa29e2f2009
#11 10.11 go: finding github.com/aws/aws-sdk-go v1.16.5
#11 10.11 go: finding gopkg.in/yaml.v2 v2.3.0
#11 10.12 go: finding github.com/russross/blackfriday v1.5.2
#11 10.12 go: finding github.com/davecgh/go-spew v1.1.1
#11 10.12 go: finding github.com/algorand/websocket v1.4.3
#11 10.13 go: finding github.com/pmezard/go-difflib v1.0.0
#11 10.14 go: finding github.com/google/go-querystring v1.0.0
#11 10.14 go: finding github.com/gorilla/mux v1.6.2
#11 10.14 go: finding github.com/miekg/dns v1.1.27
#11 10.14 go: finding gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
#11 10.15 go: finding golang.org/x/net v0.0.0-20200904194848-62affa334b73
#11 10.15 go: finding github.com/ghodss/yaml v1.0.0
#11 10.15 go: finding golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c
#11 10.16 go: finding github.com/mailru/easyjson v0.7.7
#11 10.17 go: finding github.com/labstack/gommon v0.3.0
#11 10.18 go: finding github.com/dgrijalva/jwt-go v3.2.0+incompatible
#11 10.18 go: finding github.com/pkg/errors v0.9.1
#11 10.18 go: finding github.com/mattn/go-colorable v0.1.7
#11 10.19 go: finding github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
#11 10.19 go: finding github.com/josharian/intern v1.0.0
#11 10.19 go: finding github.com/mattn/go-isatty v0.0.12
#11 10.20 go: finding golang.org/x/text v0.3.3
#11 10.20 go: finding github.com/valyala/fasttemplate v1.2.1
#11 10.20 go: finding github.com/dchest/siphash v1.2.1
#11 10.21 go: finding github.com/jmoiron/sqlx v1.2.0
#11 10.22 go: finding github.com/karalabe/hid v1.0.0
#11 10.22 go: finding github.com/valyala/bytebufferpool v1.0.0
#11 10.23 go: finding github.com/fatih/color v1.7.0
#11 10.23 go: finding github.com/gen2brain/beeep v0.0.0-20180718162406-4e430518395f
#11 10.25 go: finding github.com/godbus/dbus v0.0.0-20181101234600-2ff6f7ffd60f
#11 10.50 mkdir -p crypto/copies/linux/amd64
#11 10.50 cp -R crypto/libsodium-fork crypto/copies/linux/amd64/libsodium-fork
#11 10.53 cd crypto/copies/linux/amd64/libsodium-fork && \
#11 10.53 	./autogen.sh --prefix /opt/indexer/third_party/go-algorand/crypto/libs/linux/amd64 && \
#11 10.53 	./configure --disable-shared --prefix="/opt/indexer/third_party/go-algorand/crypto/libs/linux/amd64" && \
#11 10.53 	make && \
#11 10.53 	make install
#11 10.53 libtool is required, but wasn't found on this system
#11 10.53 make[1]: *** [Makefile:133: crypto/libs/linux/amd64/lib/libsodium.a] Error 1
#11 10.53 make[1]: Leaving directory '/opt/indexer/third_party/go-algorand'
#11 10.53 make: *** [Makefile:22: go-algorand] Error 2
------
executor failed running [/bin/sh -c /tmp/install.sh]: exit code: 2
ERROR: Service 'indexer' failed to build : Build failed

```

This PR fixes this error by switching the Indexer Docker image to Ubuntu and including manually libtool inside.
`alpine` indeed does not have a proper version of lib tool that allows compilation of `go-algorand`.

This PR also solves [Installation crashes · Issue #85 · algorand/sandbox · GitHub](https://github.com/algorand/sandbox/issues/85#issuecomment-980590584)