### PR TITLE
Bump golang image tag to 1.16.11

### DIFF
--- a/images/algod/Dockerfile
+++ b/images/algod/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14.7
+FROM golang:1.16.11
 
 ARG CHANNEL=nightly
 ARG URL=


### PR DESCRIPTION
Simply bumped up the tag for the `golang` image used the `algod` Dockerfile to `1.16.11` to align with [this commit](https://github.com/algorand/go-algorand/commit/f51d2d7d5af1ef634bad99afeb1a910efe245177). 

Without this change, `./sandbox up -v` will fail to run successfully due to the version of Go being incorrect for `go-algorand`

```
[./scripts/check_golang_version.sh] ERROR: The version of go on the system (1.14.7) is too old and does not support go modules. Please update to at least 1.16
ERROR: Service 'algod' failed to build: The command '/bin/sh -c /tmp/images/algod/install.sh     -d "${BIN_DIR}"     -c "${CHANNEL}"     -u "${URL}"     -b "${BRANCH}"     -s "${SHA}"' returned a non-zero code: 1
```