### PR TITLE
Add Docker Hub login to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
-script:
-  - set -e
-  - if [ -n "$DOCKER_PASSWORD" ]; then echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin ; fi
-
 jobs:
   include:
     # Focal
@@ -119,4 +115,6 @@ services:
   - docker
 
 script:
+  - set -e
+  - if [ -n "$DOCKER_PASSWORD" ]; then echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin ; fi
   - ./sandbox up -v $CONFIG

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+script:
+  - set -e
+  - if [ -n "$DOCKER_PASSWORD" ]; then echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin ; fi
+
 jobs:
   include:
     # Focal


### PR DESCRIPTION
This is a stop gap measure to unblock sandbox testing. The proper solution is to move this to Github Actions or CircleCI.
