### PR TITLE
Wait for REST services to start before printing information.

### DIFF
--- a/sandbox
+++ b/sandbox
@@ -224,6 +224,37 @@ sandbox () {
     fi    
   }
 
+  # wait until indexer/algod health endpoints report 200
+  wait_for_services() {
+    local ATTEMPTS_REMAINING
+    local INDEXER_STATUS
+    local ALGOD_STATUS
+
+    # wait for startup
+    ATTEMPTS_REMAINING=20
+    while [[ $ATTEMPTS_REMAINING -gt 0 ]]; do
+      INDEXER_STATUS=$(curl -sL -w "%{http_code}\n" "localhost:8980/health" -o /dev/null || true)
+      ALGOD_STATUS=$(curl -sL -w "%{http_code}\n" "localhost:4001/health" -o /dev/null || true)
+      if [ $ALGOD_STATUS == "200" ] && [ $INDEXER_STATUS == "200" ]; then
+        ATTEMPTS_REMAINING=0
+      fi
+
+      ((ATTEMPTS_REMAINING=ATTEMPTS_REMAINING-1))
+      sleep 1
+    done
+
+    if [ $ALGOD_STATUS != "200" ] || [ $INDEXER_STATUS != "200" ]; then
+      echo "the following did not start:"
+      if [ $ALGOD_STATUS != "200" ]; then
+        echo "* algorand node"
+      fi
+      if [ $INDEXER_STATUS != "200" ]; then
+        echo "* indexer node"
+      fi
+      err "\none or more services failed to start."
+    fi
+  }
+
   version_helper () {
     statusline "algod version"
     dc exec algod goal -v
@@ -430,14 +461,16 @@ sandbox () {
         rebuild_if_needed >> "$SANDBOX_LOG" 2>&1               & spinner
         echo "* docker-compose up -d"   >> "$SANDBOX_LOG"
         dc up -d                        >> "$SANDBOX_LOG" 2>&1 & spinner
-        sleep 1                                                & spinner
-        overwrite "* started!"
+        overwrite "* docker containers started!"
       else
         rebuild_if_needed
         echo "* docker-compose up -d"
         dc up -d
-        sleep 1
       fi
+
+      echo -e "* waiting for services to initialize.\n"
+      wait_for_services & spinner
+      overwrite "* services ready!"
 
       version_helper
       status_helper


### PR DESCRIPTION
The hard coded 1 second wait time is not always sufficient. The services continue to start, but an error status is returned and status info is not printed.

This addresses the problem by waiting for the health endpoints on algod and indexer to return a `200` code in place of the 1 second delay.