### PR TITLE
Fix version command for indexer

### DIFF
--- a/sandbox
+++ b/sandbox
@@ -258,7 +258,8 @@ sandbox () {
     statusline "algod version"
     dc exec algod goal -v
     statusline "Indexer version"
-    INDEXER_VERSION=$(dc exec indexer cmd/algorand-indexer/algorand-indexer -v) && echo ${INDEXER_VERSION} || curl -s "localhost:8980/health?pretty"
+    # the algorand-indexer command doesn't have a version command without either import or daemon arguments
+    INDEXER_VERSION=$(dc exec indexer cmd/algorand-indexer/algorand-indexer import -v) && echo ${INDEXER_VERSION} || curl -s "localhost:8980/health?pretty"
     statusline "Postgres version"
     dc exec indexer-db postgres -V
   }

--- a/sandbox
+++ b/sandbox
@@ -258,8 +258,7 @@ sandbox () {
     statusline "algod version"
     dc exec algod goal -v
     statusline "Indexer version"
-    # the algorand-indexer command doesn't have a version command without either import or daemon arguments
-    INDEXER_VERSION=$(dc exec indexer cmd/algorand-indexer/algorand-indexer import -v) && echo ${INDEXER_VERSION} || curl -s "localhost:8980/health?pretty"
+    INDEXER_VERSION=$(dc exec indexer cmd/algorand-indexer/algorand-indexer daemon -v) && echo ${INDEXER_VERSION} || curl -s "localhost:8980/health?pretty"
     statusline "Postgres version"
     dc exec indexer-db postgres -V
   }


### PR DESCRIPTION
## Summary
While working on [this indexer issue](https://github.com/algorand/indexer/issues/486) I noticed that the version command for `algorand-indexer -v` was returning an error.

```
Indexer version
Error: unknown shorthand flag: 'v' in -v
Usage:
  indexer [flags]
  indexer [command]

Available Commands:
  daemon      run indexer daemon
  help        Help about any command
  util        Utilities for testing Indexer operation and correctness.

Flags:
  -h, --help   help for indexer

Use "indexer [command] --help" for more information about a command.
```

This is because the indexer command [does not register version to the base command](https://github.com/algorand/indexer/blob/develop/cmd/algorand-indexer/main.go#L142) 
Updated the command to fix this and the error dissapears.

```
Indexer version
2.10.0-dev.unknown compiled at 2022-04-11T20:08:35+0000 from git hash 4c5201d99815a66b8b0dd23d4910570714810d82 (modified)
```
