### PR TITLE
Generate fewer participation keys.

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Private networks also include an `Indexer` service configured to synchronize aga
 
 The `dev` configuration runs a private network in dev mode. In this mode, every transaction being sent to the node automatically generates a new block, rather than wait for a new round in real time. This is extremely useful for fast e2e testing of an application.
 
+It takes a long time to generate participation keys, so the default configurations use the `NETWORK_NUM_ROUNDS` parameter to limit how many are created. Unless the default value is changed, the network will stall after 24 hours. Some configurations have been changed so that they can be run for over a week. Review the setting to make sure it is suitable for how you would like to use the sandbox.
+
 ### Public Network
 
 The `mainnet`, `testnet`, `betanet`, and `devnet` configurations configure the sandbox to connect to one of those long running networks. Once started it will automatically attempt to catchup to the latest round. Catchup tends to take a while and a progress bar will be displayed to illustrate of the progress.
@@ -175,8 +177,11 @@ export ALGOD_CHANNEL="nightly"
 export ALGOD_URL=""
 export ALGOD_BRANCH=""
 export ALGOD_SHA=""
-export ALGOD_BOOTSTRAP_URL=""
-export ALGOD_GENESIS_FILE=""
+export NETWORK=""
+export NETWORK_TEMPLATE="images/algod/future_template.json"
+export NETWORK_NUM_ROUNDS=300000
+export NETWORK_BOOTSTRAP_URL=""
+export NETWORK_GENESIS_FILE=""
 export INDEXER_URL="https://github.com/algorand/indexer"
 export INDEXER_BRANCH="develop"
 export INDEXER_SHA=""

--- a/config.beta
+++ b/config.beta
@@ -4,6 +4,7 @@ export ALGOD_BRANCH=""
 export ALGOD_SHA=""
 export NETWORK=""
 export NETWORK_BOOTSTRAP_URL=""
+export NETWORK_NUM_ROUNDS=300000
 export NETWORK_GENESIS_FILE=""
 export INDEXER_URL="https://github.com/algorand/indexer"
 export INDEXER_BRANCH="develop"

--- a/config.dev
+++ b/config.dev
@@ -4,6 +4,7 @@ export ALGOD_BRANCH="master"
 export ALGOD_SHA=""
 export NETWORK=""
 export NETWORK_TEMPLATE="images/algod/DevModeNetwork.json"
+export NETWORK_NUM_ROUNDS=30000
 export NETWORK_BOOTSTRAP_URL=""
 export NETWORK_GENESIS_FILE=""
 export INDEXER_URL="https://github.com/algorand/indexer"

--- a/config.nightly
+++ b/config.nightly
@@ -4,6 +4,7 @@ export ALGOD_BRANCH=""
 export ALGOD_SHA=""
 export NETWORK=""
 export NETWORK_TEMPLATE="images/algod/future_template.json"
+export NETWORK_NUM_ROUNDS=300000
 export NETWORK_BOOTSTRAP_URL=""
 export NETWORK_GENESIS_FILE=""
 export INDEXER_URL="https://github.com/algorand/indexer"

--- a/config.release
+++ b/config.release
@@ -3,6 +3,7 @@ export ALGOD_URL=""
 export ALGOD_BRANCH=""
 export ALGOD_SHA=""
 export NETWORK=""
+export NETWORK_NUM_ROUNDS=300000
 export NETWORK_BOOTSTRAP_URL=""
 export NETWORK_GENESIS_FILE=""
 export INDEXER_URL="https://github.com/algorand/indexer"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
         BOOTSTRAP_URL: "${NETWORK_BOOTSTRAP_URL}"
         GENESIS_FILE: "${NETWORK_GENESIS_FILE}"
         TEMPLATE: "${NETWORK_TEMPLATE:-images/algod/template.json}"
+        NETWORK_NUM_ROUNDS: "${NETWORK_NUM_ROUNDS:-30000}"
         TOKEN: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         ALGOD_PORT: "4001"
         KMD_PORT: "4002"

--- a/images/algod/DevModeNetwork.json
+++ b/images/algod/DevModeNetwork.json
@@ -2,6 +2,8 @@
     "Genesis": {
         "ConsensusProtocol": "future",
         "NetworkName": "devmodenet",
+        "FirstPartKeyRound": 0,
+        "LastPartKeyRound":  30000,
         "Wallets": [
             {
                 "Name": "Wallet1",

--- a/images/algod/DevModeNetwork.json
+++ b/images/algod/DevModeNetwork.json
@@ -3,7 +3,7 @@
         "ConsensusProtocol": "future",
         "NetworkName": "devmodenet",
         "FirstPartKeyRound": 0,
-        "LastPartKeyRound":  30000,
+        "LastPartKeyRound":  NETWORK_NUM_ROUNDS,
         "Wallets": [
             {
                 "Name": "Wallet1",

--- a/images/algod/Dockerfile
+++ b/images/algod/Dockerfile
@@ -15,6 +15,7 @@ ARG ALGOD_PORT=""
 ARG KMD_PORT=""
 ARG TOKEN=""
 ARG TEMPLATE=""
+ARG NETWORK_NUM_ROUNDS="30000"
 
 RUN echo "Installing from source. ${URL} -- ${BRANCH}"
 ENV BIN_DIR="$HOME/node"
@@ -38,7 +39,8 @@ RUN /tmp/images/algod/install.sh \
     -s "${SHA}"
 
 # Configure network
-RUN /tmp/images/algod/setup.py \
+RUN sed -i "s/NETWORK_NUM_ROUNDS/$NETWORK_NUM_ROUNDS/" "//tmp/${TEMPLATE}" && \
+ /tmp/images/algod/setup.py \
  --bin-dir "$BIN_DIR" \
  --data-dir "/opt/data" \
  --start-script "/opt/start_algod.sh" \

--- a/images/algod/future_template.json
+++ b/images/algod/future_template.json
@@ -2,6 +2,8 @@
     "Genesis": {
         "ConsensusProtocol": "future",
         "NetworkName": "",
+        "FirstPartKeyRound": 0,
+        "LastPartKeyRound":  30000,
         "Wallets": [
             {
                 "Name": "Wallet1",

--- a/images/algod/future_template.json
+++ b/images/algod/future_template.json
@@ -3,7 +3,7 @@
         "ConsensusProtocol": "future",
         "NetworkName": "",
         "FirstPartKeyRound": 0,
-        "LastPartKeyRound":  30000,
+        "LastPartKeyRound":  NETWORK_NUM_ROUNDS,
         "Wallets": [
             {
                 "Name": "Wallet1",

--- a/images/algod/template.json
+++ b/images/algod/template.json
@@ -2,7 +2,7 @@
     "Genesis": {
         "NetworkName": "",
         "FirstPartKeyRound": 0,
-        "LastPartKeyRound":  30000,
+        "LastPartKeyRound":  NETWORK_NUM_ROUNDS,
         "Wallets": [
             {
                 "Name": "Wallet1",

--- a/images/algod/template.json
+++ b/images/algod/template.json
@@ -1,6 +1,8 @@
 {
     "Genesis": {
         "NetworkName": "",
+        "FirstPartKeyRound": 0,
+        "LastPartKeyRound":  30000,
         "Wallets": [
             {
                 "Name": "Wallet1",


### PR DESCRIPTION
The new falcon keys take a long time to generate. With this change the templates are updated to specify a reduced number (30000) of keys to generate. A side effect of this change means that the private sandbox networks will stall sometime within 24-48 hours.

Closes #109 