### PR TITLE
Support upcoming indexer data directory.

### DIFF
--- a/images/indexer/start.sh
+++ b/images/indexer/start.sh
@@ -62,6 +62,10 @@ disabled() {
   go run /tmp/disabled.go -port "$PORT" -code 200 -message "Indexer disabled for this configuration."
 }
 
+# Make sure data directory is available in case we're using a version that requires it.
+export INDEXER_DATA=/tmp/indexer-data
+mkdir -p ${INDEXER_DATA}
+
 if [ ! -z "$DISABLED" ]; then
   disabled
 elif [ -z "${SNAPSHOT}" ]; then


### PR DESCRIPTION
Se the Indexer data directory option, which is currently in the indexer dev branch. By setting it with an environment variable we can be backwards compatible with versions that don't support this option.