### PR TITLE
Remove ubuntu 16.04 and add 22.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 version: 2.1
 
 parameters:
+  ubuntu_jammy_machine:
+    type: string
+    default: 'ubuntu-2204'
   ubuntu_focal_machine:
     type: string
-    default: 'ubuntu-2004:202111-02'
-  ubuntu_xenial_machine:
-    type: string
-    default: 'ubuntu-1604:202104-01'
+    default: 'ubuntu-2004'
 
 workflows:
   circleci_build_and_test:
@@ -16,7 +16,7 @@ workflows:
           matrix:
             parameters:
               config: ['', 'betanet', 'testnet', 'devnet', 'dev', 'beta', 'release', 'nightly']
-              machine: [<< pipeline.parameters.ubuntu_focal_machine >>, << pipeline.parameters.ubuntu_xenial_machine >>]
+              machine: [<< pipeline.parameters.ubuntu_focal_machine >>, << pipeline.parameters.ubuntu_jammy_machine >>]
 
 jobs:
   spin_up:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,10 @@ version: 2.1
 parameters:
   ubuntu_jammy_machine:
     type: string
-    default: 'cimg/base:2022.04'
+    default: 'ubuntu/22.04'
   ubuntu_focal_machine:
     type: string
-    default: 'cimg/base:2020.04'
+    default: 'ubuntu/20.04'
 
 workflows:
   circleci_build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,10 @@ version: 2.1
 parameters:
   ubuntu_jammy_machine:
     type: string
-    default: 'ubuntu-2204'
+    default: 'cimg/base:2022.04'
   ubuntu_focal_machine:
     type: string
-    default: 'ubuntu-2004'
+    default: 'cimg/base:2020.04'
 
 workflows:
   circleci_build_and_test:


### PR DESCRIPTION
There was a test failure because 16.04 was not found. There is no need to support this old version, so replacing it with a recent LTS release.