### PR TITLE
updating CI tests to ubuntu 22.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,9 @@ parameters:
   ubuntu_focal_machine:
     type: string
     default: 'ubuntu-2004:202111-02'
-  ubuntu_xenial_machine:
+  ubuntu_jammy_machine:
     type: string
-    default: 'ubuntu-1604:202104-01'
+    default: 'ubuntu-2204:2022.04.1'
 
 workflows:
   circleci_build_and_test:
@@ -16,7 +16,7 @@ workflows:
           matrix:
             parameters:
               config: ['', 'betanet', 'testnet', 'devnet', 'dev', 'beta', 'release', 'nightly']
-              machine: [<< pipeline.parameters.ubuntu_focal_machine >>, << pipeline.parameters.ubuntu_xenial_machine >>]
+              machine: [<< pipeline.parameters.ubuntu_focal_machine >>, << pipeline.parameters.ubuntu_jammy_machine >>]
 
 jobs:
   spin_up:


### PR DESCRIPTION
ubuntu 16 was deprecated, so upgraded to next available one