### PR TITLE
Updated docker compose command for new style

### DIFF
--- a/sandbox
+++ b/sandbox
@@ -31,6 +31,18 @@ export INDEXER_BRANCH=""
 export INDEXER_SHA=""
 export INDEXER_DISABLED=""
 
+##################################################
+# Determine the correct docker command (or fail) #
+##################################################
+if [ -x "$(command -v docker-compose)" ]; then
+  DOCKER_COMPOSE="docker-compose"
+elif [ "$(docker compose help &>/dev/null; echo "$?")" -eq 16 ]; then
+  DOCKER_COMPOSE="docker compose"
+else
+  echo 'Error: docker compose is not installed.' >&2
+  exit 1
+fi
+
 ######################################
 # Compatibility with Windows / MSYS2 #
 ######################################
@@ -181,7 +193,7 @@ sandbox () {
   }
 
   dc () {
-    docker-compose -f "$SANDBOX_DIR/docker-compose.yml" "$@"
+    $DOCKER_COMPOSE -f "$SANDBOX_DIR/docker-compose.yml" "$@"
   }
 
   # dc is used when a pseudo-TTY is required
@@ -190,14 +202,14 @@ sandbox () {
   dc_pty () {
     # note: cannot be replaced by $WINDOWS_PTY_PREFIX dc "$@"
     #       because winpty requires an executable as argument
-    $WINDOWS_PTY_PREFIX docker-compose -f "$SANDBOX_DIR/docker-compose.yml" "$@"
+    $WINDOWS_PTY_PREFIX $DOCKER_COMPOSE -f "$SANDBOX_DIR/docker-compose.yml" "$@"
   }
 
   rebuild_if_needed () {
     if [ -f "$CLEAN_FILE" ]; then
       rm "$CLEAN_FILE"
       echo ".clean file found in sandbox directory. Rebuilding images..."
-      echo "* docker-compose build --no-cache"
+      echo "* docker compose build --no-cache"
       dc build --no-cache
     elif [ $FRESH_INSTALL -eq 0 ]; then
       echo ".clean file NOT FOUND. Sandbox images will NOT be rebuilt."
@@ -345,11 +357,11 @@ sandbox () {
   }
 
   clean () {
-    echo "* docker-compose down"
+    echo "* docker compose down"
     dc down -t 0                                   || true
     echo "* docker rmi sandbox_algod sandbox_indexer"
     docker rmi sandbox_algod sandbox_indexer                   || true
-    echo "* docker-compose rm -f"
+    echo "* docker compose rm -f"
     dc rm -f                                       || true
     echo "* docker rmi $(docker images -f "dangling=true" -q)"
     docker rmi $(docker images -f "dangling=true" -q)          || true
@@ -458,12 +470,12 @@ sandbox () {
         echo "see sandbox.log for detailed progress, or use -v."
         echo "" # The spinner will rewrite this line.
         rebuild_if_needed >> "$SANDBOX_LOG" 2>&1               & spinner
-        echo "* docker-compose up -d"   >> "$SANDBOX_LOG"
+        echo "* docker compose up -d"   >> "$SANDBOX_LOG"
         dc up -d                        >> "$SANDBOX_LOG" 2>&1 & spinner
         overwrite "* docker containers started!"
       else
         rebuild_if_needed
-        echo "* docker-compose up -d"
+        echo "* docker compose up -d"
         dc up -d
       fi
 
@@ -538,7 +550,7 @@ algorand commands:
 special flags for 'up' command:
   -v|--verbose           -> display verbose output when starting standbox.
   -s|--skip-fast-catchup -> skip catchup when connecting to real network.
-  -i|--interactive       -> start docker-compose in interactive mode.
+  -i|--interactive       -> start docker compose in interactive mode.
 EOF
   }
 
@@ -669,10 +681,5 @@ EOF
 ##############
 # Entrypoint #
 ##############
-
-if ! [ -x "$(command -v docker-compose)" ]; then
-  echo 'Error: docker-compose is not installed.' >&2
-  exit 1
-fi
 
 sandbox "$@"


### PR DESCRIPTION
Docker has relaunched `compose` as an official plugin in the new style. When I first ran `./sandbox up testnet` per your instructions, it failed because it couldn't find `docker-compose` on my system. This change simply allows the script to detect and use whichever version of docker compose is available - the stand-alone `docker-compose` version or the new plugin-based `docker compose`. (This is a take-it-or-leave-it PR! Don't feel bad about rejecting it if you're not interested.)