### PR TITLE
Bug-fix: more explicit sourcing of .env

### DIFF
--- a/sandbox
+++ b/sandbox
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-source .env
-
 #####################
 # Script constants. #
 #####################

--- a/sandbox
+++ b/sandbox
@@ -8,6 +8,7 @@ source .env
 #####################
 DEFAULT_CONFIG='release'
 SANDBOX_DIR=$(dirname "$0")
+source "$SANDBOX_DIR/.env"
 CLEAN_FILE="$SANDBOX_DIR/.clean"
 ACTIVE_CONFIG_FILE="$SANDBOX_DIR/.active_config"
 SANDBOX_LOG="$SANDBOX_DIR/sandbox.log"


### PR DESCRIPTION
# Bugfix for bug introduced in #136 

The recent exposing of `.env` in #136 broke the way some developers, including @barnjamin , have their aliases set up to use the sandbox. This PR should fix the problem by sourcing _after_ setting the `$SANDBOX_DIR` variable.

## Testing
* Sandboxe's CI is passing
* The [python SDK branch](https://github.com/algorand/py-algorand-sdk/blob/0878b23603e6bc33081cbfbbb71649634e7d0158/.test-env#L30) that is depending on this change is [passing as well](https://app.circleci.com/pipelines/github/algorand/py-algorand-sdk/816/workflows/79e74c8c-b4c4-4116-98c2-d667c47f1dd0/jobs/3451).