### PR TITLE
prevent download/build of indexer requirements if set to disabled

### DIFF
--- a/sandbox
+++ b/sandbox
@@ -215,7 +215,13 @@ sandbox () {
       VERBOSE_FLAG=" --verbose"
     fi
 
-    $DOCKER_COMPOSE$VERBOSE_FLAG -f "$SANDBOX_DIR/docker-compose.yml" "$@"
+    $DOCKER_COMPOSE$VERBOSE_FLAG -f "$SANDBOX_DIR/docker-compose.yml" "$@" algod
+
+    if [[ $INDEXER_DISABLED != "true" ]]; then
+        $DOCKER_COMPOSE$VERBOSE_FLAG -f "$SANDBOX_DIR/docker-compose.yml" "$@" indexer_db
+        $DOCKER_COMPOSE$VERBOSE_FLAG -f "$SANDBOX_DIR/docker-compose.yml" "$@" indexer
+    fi
+
   }
 
   # dc_pty needs to be used instead of dc any time
@@ -227,7 +233,12 @@ sandbox () {
     # note: cannot be replaced by $WINDOWS_PTY_PREFIX dc "$@"
     #       because winpty requires an executable as argument
     # TODO: can windows docker handle --verbose?
-    $WINDOWS_PTY_PREFIX $DOCKER_COMPOSE -f "$SANDBOX_DIR/docker-compose.yml" "$@"
+    $WINDOWS_PTY_PREFIX $DOCKER_COMPOSE -f "$SANDBOX_DIR/docker-compose.yml" "$@" algod
+
+    if [[ $INDEXER_DISABLED != "true" ]]; then
+        $DOCKER_COMPOSE$VERBOSE_FLAG -f "$SANDBOX_DIR/docker-compose.yml" "$@" indexer_db
+        $DOCKER_COMPOSE$VERBOSE_FLAG -f "$SANDBOX_DIR/docker-compose.yml" "$@" indexer
+    fi
   }
 
   rebuild_if_needed () {


### PR DESCRIPTION
For CI with sandbox, I don't want the indexer so I set it to disabled.  At the moment the indexer services are still taking time to download and build. 

This PR adds a check for `INDEXER_DISABLED` and skips starting the services if its true. 

More needs to be done here since assumptions are taken across other commands about the status of the services
