### PR TITLE
lower case t flag for tty

### DIFF
--- a/sandbox
+++ b/sandbox
@@ -245,7 +245,7 @@ sandbox () {
   # It assumes the command is non-interactive and does not use a pseudo-TTY
   # (option -T)
   goal_helper () {
-    dc exec -T algod goal "$@"
+    dc exec -t algod goal "$@"
   }
 
   # A shortcut for tealdbg commands on docker-compose


### PR DESCRIPTION
If you're running a command like `./sandbox goal wallet new $WALLET_NAME` it will try to prompt you for a password.

With the `-T` flag an error occurs "inappropriate ioctl for device"

Switching it to lowercase `-t` seems to work but I recall there was some weirdness with other shell options like gitbash/mingw

```
ben@Algo-Guidarelli:~/sandbox$ docker compose exec --help

Usage:  docker compose exec [options] [-e KEY=VAL...] [--] SERVICE COMMAND [ARGS...]

Execute a command in a running container.

Options:
  -d, --detach                       Detached mode: Run command in the background.
  -e, --env stringArray              Set environment variables
      --index int                    index of the container if there are multiple instances of a service [default: 1]. (default 1)
  -T, --no-TTY docker compose exec   Disable pseudo-TTY allocation. By default docker compose exec allocates a TTY.
      --privileged                   Give extended privileges to the process.
  -u, --user string                  Run the command as this user.
  -w, --workdir string               Path to workdir directory for this command.
ben@Algo-Guidarelli:~/sandbox$ docker exec --help

Usage:  docker exec [OPTIONS] CONTAINER COMMAND [ARG...]

Run a command in a running container

Options:
  -d, --detach               Detached mode: run command in the background
      --detach-keys string   Override the key sequence for detaching a container
  -e, --env list             Set environment variables
      --env-file list        Read in a file of environment variables
  -i, --interactive          Keep STDIN open even if not attached
      --privileged           Give extended privileges to the command
  -t, --tty                  Allocate a pseudo-TTY
  -u, --user string          Username or UID (format: <name|uid>[:<group|gid>])
  -w, --workdir string       Working directory inside the container
  ```