### PR TITLE
Add default value to network reset prompt.

### DIFF
--- a/sandbox
+++ b/sandbox
@@ -103,7 +103,7 @@ function overwrite() {
 
 # Yes/no prompt around the clean command
 function ask_clean () {
-  if ask "$1"; then
+  if ask "$1" "Y"; then
     sandbox clean
   else
     exit 1


### PR DESCRIPTION
When switching networks, pressing enter with no value now defaults to "yes".

This is indicated following bash conventions by present a capitol `Y` with the prompt:
```diff
- Would you like to reset the local sandbox with 'mainnet'? [y/n]
+ Would you like to reset the local sandbox with 'mainnet'? [Y/n]
```