### PR TITLE
service "algod" is not running container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.2'
 
 services:
   algod:


### PR DESCRIPTION
The type of services.algod.volumes is incorrect; it should be a string. Error. The setting for Docker.yml file should be 3.2, not 3.