### PR TITLE
Sandbox improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
     depends_on:
       - indexer-db
       - algod
-      
+
   indexer-db:
     image: "postgres:13-alpine"
     container_name: "${POSTGRES_CONTAINER:-algorand-sandbox-postgres}"

--- a/images/algod/DevModeNetwork.json
+++ b/images/algod/DevModeNetwork.json
@@ -1,6 +1,5 @@
 {
     "Genesis": {
-        "ConsensusProtocol": "future",
         "NetworkName": "devmodenet",
         "FirstPartKeyRound": 0,
         "LastPartKeyRound":  NETWORK_NUM_ROUNDS,

--- a/images/indexer/start.sh
+++ b/images/indexer/start.sh
@@ -15,25 +15,19 @@ set -e
 start_with_algod() {
   echo "Starting indexer against algod."
 
+  # wait for algod to start
   for i in 1 2 3 4 5; do
-    wget "${ALGOD_ADDR}"/genesis -O genesis.json && break
+    wget "${ALGOD_ADDR}"/genesis && break
     echo "Algod not responding... waiting."
     sleep 15
   done
-
-  if [ ! -f genesis.json ]; then
-    echo "Failed to create genesis file!"
-    exit 1
-  fi
 
   /tmp/algorand-indexer daemon \
     --dev-mode \
     --server ":$PORT" \
     -P "$CONNECTION_STRING" \
     --algod-net "${ALGOD_ADDR}" \
-    --algod-token "${ALGOD_TOKEN}" \
-    --genesis "genesis.json" \
-    --logfile "/tmp/indexer-log.txt" >> /tmp/command.txt
+    --algod-token "${ALGOD_TOKEN}"
 }
 
 import_and_start_readonly() {
@@ -48,14 +42,12 @@ import_and_start_readonly() {
   /tmp/algorand-indexer import \
     -P "$CONNECTION_STRING" \
     --genesis "/tmp/indexer-snapshot/algod/genesis.json" \
-    /tmp/indexer-snapshot/blocktars/* \
-    --logfile "/tmp/indexer-log.txt" >> /tmp/command.txt
+    /tmp/indexer-snapshot/blocktars/*
 
   /tmp/algorand-indexer daemon \
     --dev-mode \
     --server ":$PORT" \
-    -P "$CONNECTION_STRING" \
-    --logfile "/tmp/indexer-log.txt" >> /tmp/command.txt
+    -P "$CONNECTION_STRING"
 }
 
 disabled() {

--- a/sandbox
+++ b/sandbox
@@ -418,8 +418,8 @@ sandbox () {
         return
         ;;
       indexer-db)
-        statusline "Entering /bin/bash session in the indexer-db container..."
-        dc_pty exec indexer-db //bin/bash
+        statusline "Entering psql session in the indexer-db container..."
+        dc_pty exec indexer-db psql -U algorand -d indexer_db
         return
         ;;
     esac


### PR DESCRIPTION
* Let Indexer fetch genesis file on its own.
* Let Indexer write output to stdout so docker logs command works.
* Remove 'future' from dev mode network.
* Connect to psql shell when entering indexer-db container.