### PR TITLE
conduit: Remove conduit retry delay

### DIFF
--- a/images/conduit/start.sh
+++ b/images/conduit/start.sh
@@ -37,6 +37,7 @@ else
     -e "s/addr: \":9999\"/addr: \":$PORT\"/" \
     -e "s/mode: OFF/mode: ON/" \
     -e "s/host= port=5432 user= password= dbname=/$CONNECTION_STRING/" \
+    -e "s/retry-delay: \"1s\"/retry-delay: \"0s\"/" \
     "${CONDUIT_DATA}"/conduit.yaml
 
   cat "${CONDUIT_DATA}"/conduit.yaml


### PR DESCRIPTION
Retry delay in conduit is set to 1s which causes a noticeable delay in blocks being picked up when used with devmode.

For example, [the JS SDK examples fail](https://app.circleci.com/pipelines/github/algorand/js-algorand-sdk/1070/workflows/f66dac28-9265-4ef2-8a5d-2799e320ce22/jobs/6451) because created ASAs are not loaded into pgsql quickly enough for indexer to show the asset.

I've tested this change against the JS SDK and the tests pass locally using 0 retry delay.