### PR TITLE
Build: Golang v20 for indexer and conduit sandbox images

### DIFF
--- a/images/conduit/Dockerfile
+++ b/images/conduit/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.17.5
+ARG GO_VERSION=1.20.5
 FROM golang:$GO_VERSION-alpine
 
 # Environment variables used by install.sh

--- a/images/indexer/Dockerfile
+++ b/images/indexer/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.17.5
+ARG GO_VERSION=1.20.5
 FROM golang:$GO_VERSION-alpine
 
 # Environment variables used by install.sh


### PR DESCRIPTION
Blocked on both [Indexer #1549](https://github.com/algorand/indexer/pull/1549) and [Indexer #1545](https://github.com/algorand/indexer/pull/1545) being merged. Conduits upgrade is in place as of this writing.