### PR TITLE
chore: Bump go version for indexer and conduit

### DIFF
--- a/images/conduit/Dockerfile
+++ b/images/conduit/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.17.5
+ARG GO_VERSION=1.20.5
 FROM golang:$GO_VERSION-alpine
 
 # Environment variables used by install.sh

--- a/images/indexer/Dockerfile
+++ b/images/indexer/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.17.5
+ARG GO_VERSION=1.20.5
 FROM golang:$GO_VERSION-alpine
 
 # Environment variables used by install.sh


### PR DESCRIPTION
Increase the installed go version in our docker images to `1.20.5` for both Indexer and Conduit.

Currently Indexer at least ( see https://app.circleci.com/pipelines/github/algorand/js-algorand-sdk/1082/workflows/61452a43-6908-4a4a-9046-32f823ee4a9b/jobs/6529 ) is failing to install and come up in Sandbox because of the go version mismatch in the build environment.