### PR TITLE
Fix conduit sed command

### DIFF
--- a/images/conduit/start.sh
+++ b/images/conduit/start.sh
@@ -32,8 +32,8 @@ elif [ ! -f /tmp/conduit ]; then
 else
   /tmp/conduit init --importer algod --exporter postgresql > "${CONDUIT_DATA}"/conduit.yaml
   sed -i \
-    -e "s/netaddr: \"http:\/\/url:port\"/netaddr: \"$ALGOD_ADDR\"/" \
-    -e "s/token: \"\"/token: \"$ALGOD_ADMIN_TOKEN\"/" \
+    -e "s/netaddr: \"http:\/\/your-algod-url:port\"/netaddr: \"$ALGOD_ADDR\"/" \
+    -e "s/token: \"contents of your algod\.token file\"/token: \"$ALGOD_ADMIN_TOKEN\"/" \
     -e "s/addr: \":9999\"/addr: \":$PORT\"/" \
     -e "s/mode: OFF/mode: ON/" \
     -e "s/host= port=5432 user= password= dbname=/$CONNECTION_STRING/" \

--- a/images/conduit/start.sh
+++ b/images/conduit/start.sh
@@ -32,7 +32,7 @@ elif [ ! -f /tmp/conduit ]; then
 else
   /tmp/conduit init --importer algod --exporter postgresql > "${CONDUIT_DATA}"/conduit.yaml
   sed -i \
-    -e "s/netaddr: \"http:\/\/your-algod-url:port\"/netaddr: \"$ALGOD_ADDR\"/" \
+    -e "s/netaddr: \"http:\/\/your\-algod\-url:port\"/netaddr: \"$ALGOD_ADDR\"/" \
     -e "s/token: \"contents of your algod\.token file\"/token: \"$ALGOD_ADMIN_TOKEN\"/" \
     -e "s/addr: \":9999\"/addr: \":$PORT\"/" \
     -e "s/mode: OFF/mode: ON/" \

--- a/images/conduit/start.sh
+++ b/images/conduit/start.sh
@@ -32,8 +32,8 @@ elif [ ! -f /tmp/conduit ]; then
 else
   /tmp/conduit init --importer algod --exporter postgresql > "${CONDUIT_DATA}"/conduit.yaml
   sed -i \
-    -e "s/netaddr: \"http:\/\/your\-algod\-url:port\"/netaddr: \"$ALGOD_ADDR\"/" \
-    -e "s/token: \"contents of your algod\.token file\"/token: \"$ALGOD_ADMIN_TOKEN\"/" \
+    -e "s/netaddr: \".*\"/netaddr: \"$ALGOD_ADDR\"/" \
+    -e "s/token: \".*\"/token: \"$ALGOD_ADMIN_TOKEN\"/" \
     -e "s/addr: \":9999\"/addr: \":$PORT\"/" \
     -e "s/mode: OFF/mode: ON/" \
     -e "s/host= port=5432 user= password= dbname=/$CONNECTION_STRING/" \


### PR DESCRIPTION
Changes the `sed` command to replace conduit address/port args for algod made by this change: https://github.com/algorand/conduit/pull/115/files#diff-25b93f09fa99b0263753a198867d9823be6b94f1fc417031b371dfed1502ff0c

Tested locally and in CI: [Before](https://app.circleci.com/pipelines/github/algorand/go-algorand-sdk/1071/workflows/6c2092d3-85b7-438f-a925-3102fedf92f9/jobs/2441) and [After](https://app.circleci.com/pipelines/github/algorand/go-algorand-sdk/1072/workflows/3aa75685-3f53-42eb-b7e0-e8c0e3102399/jobs/2442)