### PR TITLE
logging: docker compose builds with --progress plain

### DIFF
--- a/sandbox
+++ b/sandbox
@@ -241,7 +241,7 @@ sandbox () {
     if [ -f "$CLEAN_FILE" ]; then
       rm "$CLEAN_FILE"
       echo ".clean file found in sandbox directory. Rebuilding images..."
-      echo "* docker compose build --no-cache"
+      echo "* docker compose build --no-cache --progress plain"
       dc build --no-cache
     elif [ $FRESH_INSTALL -eq 0 ]; then
       echo ".clean file NOT FOUND. Sandbox images will NOT be rebuilt."

--- a/sandbox
+++ b/sandbox
@@ -242,7 +242,7 @@ sandbox () {
       rm "$CLEAN_FILE"
       echo ".clean file found in sandbox directory. Rebuilding images..."
       echo "* docker compose build --no-cache --progress plain"
-      dc build --no-cache
+      dc build --no-cache --progress plain
     elif [ $FRESH_INSTALL -eq 0 ]; then
       echo ".clean file NOT FOUND. Sandbox images will NOT be rebuilt."
     fi


### PR DESCRIPTION
progress --plain provides docker build output but without the timer updates.  The default, auto, was providing a subsecond timer update that fills our build artifacts.  thoughts?