### PR TITLE
Enable PNA headers

### DIFF
--- a/images/algod/setup.py
+++ b/images/algod/setup.py
@@ -117,9 +117,9 @@ def configure_data_dir(network_dir, token, algod_port, kmd_port, bootstrap_url, 
     node_config_path = join(node_dir, "config.json")
     archival = 'true' if archival else 'false'
     if has_follower:
-        node_config = f'{{ "Version": 27, "GossipFanout": 1, "EndpointAddress": "0.0.0.0:{algod_port}", "Archival":{archival}, "EnableDeveloperAPI":true, "NetAddress": "127.0.0.1:0", "DNSBootstrapID": "{bootstrap_url}", "EnableTxnEvalTracer": true, "MaxAcctLookback": 256}}'
+        node_config = f'{{ "Version": 34, "GossipFanout": 1, "EndpointAddress": "0.0.0.0:{algod_port}", "EnablePrivateNetworkAccessHeader": true, "Archival":{archival}, "EnableDeveloperAPI":true, "NetAddress": "127.0.0.1:0", "DNSBootstrapID": "{bootstrap_url}", "EnableTxnEvalTracer": true, "MaxAcctLookback": 256}}'
     else:
-        node_config = f'{{ "Version": 12, "GossipFanout": 1, "EndpointAddress": "0.0.0.0:{algod_port}", "DNSBootstrapID": "{bootstrap_url}", "IncomingConnectionsLimit": 0, "Archival":{archival}, "EnableDeveloperAPI":true, "EnableTxnEvalTracer": true, "MaxAcctLookback": 256}}'
+        node_config = f'{{ "Version": 34, "GossipFanout": 1, "EndpointAddress": "0.0.0.0:{algod_port}", "EnablePrivateNetworkAccessHeader": true, "DNSBootstrapID": "{bootstrap_url}", "IncomingConnectionsLimit": 0, "Archival":{archival}, "EnableDeveloperAPI":true, "EnableTxnEvalTracer": true, "MaxAcctLookback": 256}}'
     print(f"writing to node_config_path=[{node_config_path}] config json: {node_config}")
     with open(node_config_path, "w") as f:
         f.write(node_config)

--- a/images/algod/setup.py
+++ b/images/algod/setup.py
@@ -125,7 +125,7 @@ def configure_data_dir(network_dir, token, algod_port, kmd_port, bootstrap_url, 
         f.write(node_config)
 
     kmd_config_path = join(kmd_dir, 'kmd_config.json')
-    kmd_config = f'{{ "address":"0.0.0.0:{kmd_port}",  "allowed_origins":["*"], "enable_private_network_access_header": true }}'
+    kmd_config = f'{{ "address":"0.0.0.0:{kmd_port}",  "allowed_origins":["*"], "allow_header_pna": true }}'
     print(f"writing to kmd_config_path=[{kmd_config_path}] config json: {kmd_config}")
     with open(kmd_config_path, 'w') as f:
         f.write(kmd_config)

--- a/images/algod/setup.py
+++ b/images/algod/setup.py
@@ -125,7 +125,7 @@ def configure_data_dir(network_dir, token, algod_port, kmd_port, bootstrap_url, 
         f.write(node_config)
 
     kmd_config_path = join(kmd_dir, 'kmd_config.json')
-    kmd_config = f'{{ "address":"0.0.0.0:{kmd_port}",  "allowed_origins":["*"] }}'
+    kmd_config = f'{{ "address":"0.0.0.0:{kmd_port}",  "allowed_origins":["*"], "enable_private_network_access_header": true }}'
     print(f"writing to kmd_config_path=[{kmd_config_path}] config json: {kmd_config}")
     with open(kmd_config_path, 'w') as f:
         f.write(kmd_config)

--- a/images/indexer/start.sh
+++ b/images/indexer/start.sh
@@ -30,6 +30,7 @@ elif [ ! -f /tmp/algorand-indexer ]; then
 else
   /tmp/algorand-indexer daemon \
     --dev-mode \
+	--enable-private-network-access-header \
     --server ":$PORT" \
     -P "$CONNECTION_STRING"
 fi


### PR DESCRIPTION
Enable Private Network Access headers by default.

algod/kmd (https://github.com/algorand/go-algorand/pull/6089) and indexer (https://github.com/algorand/indexer/pull/1620) are both required for this PR.