### PR TITLE
Algod: Max Account Lookback Configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,12 @@
 version: 2.1
 
 parameters:
-  ubuntu_focal_machine:
+  ubuntu_noble_machine:
     type: string
-    default: 'ubuntu-2404:2024.05.1'
+    default: 'ubuntu-2404:2024.11.1'
   ubuntu_jammy_machine:
     type: string
-    default: 'ubuntu-2404:2024.05.1'
-
+    default: 'ubuntu-2204:2024.11.1'
 workflows:
   circleci_build_and_test:
     jobs:
@@ -16,7 +15,7 @@ workflows:
           matrix:
             parameters:
               config: ['', 'betanet', 'devnet', 'dev', 'beta', 'release', 'nightly']
-              machine: [<< pipeline.parameters.ubuntu_focal_machine >>, << pipeline.parameters.ubuntu_jammy_machine >>]
+              machine: [<< pipeline.parameters.ubuntu_noble_machine >>, << pipeline.parameters.ubuntu_jammy_machine >>]
 
 jobs:
   spin_up:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
         TEMPLATE: "${NETWORK_TEMPLATE:-images/algod/template.json}"
         NETWORK_NUM_ROUNDS: "${NETWORK_NUM_ROUNDS:-30000}"
         NODE_ARCHIVAL: "${NODE_ARCHIVAL}"
+        MAX_ACCOUNT_LOOKBACK: "${MAX_ACCOUNT_LOOKBACK}"
         TOKEN: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         ALGOD_PORT: "4001"
         KMD_PORT: "4002"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
         TEMPLATE: "${NETWORK_TEMPLATE:-images/algod/template.json}"
         NETWORK_NUM_ROUNDS: "${NETWORK_NUM_ROUNDS:-30000}"
         NODE_ARCHIVAL: "${NODE_ARCHIVAL}"
-        MAX_ACCOUNT_LOOKBACK: "${MAX_ACCOUNT_LOOKBACK}"
+        MAX_ACCOUNT_LOOKBACK: "${MAX_ACCOUNT_LOOKBACK:-256}"
         TOKEN: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         ALGOD_PORT: "4001"
         KMD_PORT: "4002"

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:24.04
 ARG channel
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/images/algod/Dockerfile
+++ b/images/algod/Dockerfile
@@ -18,6 +18,7 @@ ARG TOKEN=""
 ARG TEMPLATE=""
 ARG NETWORK_NUM_ROUNDS="30000"
 ARG NODE_ARCHIVAL=""
+ARG MAX_ACCOUNT_LOOKBACK=256
 
 RUN echo "Installing from source. ${URL} -- ${BRANCH}"
 ENV BIN_DIR="$HOME/node"
@@ -55,7 +56,8 @@ RUN sed -i \
  --kmd-port "${KMD_PORT}" \
  --bootstrap-url "${BOOTSTRAP_URL}" \
  --genesis-file "/tmp/${GENESIS_FILE}" \
- --archival "${NODE_ARCHIVAL}"
+ --archival "${NODE_ARCHIVAL}" \
+ --max-account-lookback "${MAX_ACCOUNT_LOOKBACK}"
 
 ENV PATH="$BIN_DIR:${PATH}"
 WORKDIR /opt/data

--- a/images/algod/setup.py
+++ b/images/algod/setup.py
@@ -36,6 +36,7 @@ parser.add_argument('--network-dir', required=True, help='Path to create network
 parser.add_argument('--bootstrap-url', required=True, help='DNS Bootstrap URL, empty for private networks.')
 parser.add_argument('--genesis-file', required=True, help='Genesis file used by the network.')
 parser.add_argument('--archival', type=bool, default=False, help='When True, bootstrap an archival node.')
+parser.add_argument('--max-account-lookback', required=True, help='Max account lookback range for account states on the node.')
 
 pp = pprint.PrettyPrinter(indent=4)
 
@@ -95,7 +96,7 @@ def create_private_network(bin_dir, network_dir, template) -> List[str]:
             '%s/kmd start -t 0 -d %s' % (bin_dir, kmd_dir)]
 
 
-def configure_data_dir(network_dir, token, algod_port, kmd_port, bootstrap_url, archival):
+def configure_data_dir(network_dir, token, algod_port, kmd_port, bootstrap_url, archival, max_account_lookback):
     node_dir, kmd_dir, follower_dir = algod_directories(network_dir)
 
     has_follower = os.path.exists(follower_dir)
@@ -117,9 +118,9 @@ def configure_data_dir(network_dir, token, algod_port, kmd_port, bootstrap_url, 
     node_config_path = join(node_dir, "config.json")
     archival = 'true' if archival else 'false'
     if has_follower:
-        node_config = f'{{ "Version": 34, "GossipFanout": 1, "EndpointAddress": "0.0.0.0:{algod_port}", "EnablePrivateNetworkAccessHeader": true, "Archival":{archival}, "EnableDeveloperAPI":true, "NetAddress": "127.0.0.1:0", "DNSBootstrapID": "{bootstrap_url}", "EnableTxnEvalTracer": true, "MaxAcctLookback": 256}}'
+        node_config = f'{{ "Version": 34, "GossipFanout": 1, "EndpointAddress": "0.0.0.0:{algod_port}", "EnablePrivateNetworkAccessHeader": true, "Archival":{archival}, "EnableDeveloperAPI":true, "NetAddress": "127.0.0.1:0", "DNSBootstrapID": "{bootstrap_url}", "EnableTxnEvalTracer": true, "MaxAcctLookback": {max_account_lookback}}}'
     else:
-        node_config = f'{{ "Version": 34, "GossipFanout": 1, "EndpointAddress": "0.0.0.0:{algod_port}", "EnablePrivateNetworkAccessHeader": true, "DNSBootstrapID": "{bootstrap_url}", "IncomingConnectionsLimit": 0, "Archival":{archival}, "EnableDeveloperAPI":true, "EnableTxnEvalTracer": true, "MaxAcctLookback": 256}}'
+        node_config = f'{{ "Version": 34, "GossipFanout": 1, "EndpointAddress": "0.0.0.0:{algod_port}", "EnablePrivateNetworkAccessHeader": true, "DNSBootstrapID": "{bootstrap_url}", "IncomingConnectionsLimit": 0, "Archival":{archival}, "EnableDeveloperAPI":true, "EnableTxnEvalTracer": true, "MaxAcctLookback": {max_account_lookback}}}'
     print(f"writing to node_config_path=[{node_config_path}] config json: {node_config}")
     with open(node_config_path, "w") as f:
         f.write(node_config)
@@ -170,5 +171,6 @@ if __name__ == '__main__':
         args.kmd_port,
         args.bootstrap_url,
         args.archival,
+        args.max_account_lookback,
     )
 


### PR DESCRIPTION
Make max-account-lookback configurable/overridable via config variable. Continues to default to 256 for sandbox deployments.