### PR TITLE
chore: Add build-base (build dep of go-algorand-sdk)

### DIFF
--- a/images/indexer/IndexerDockerfile
+++ b/images/indexer/IndexerDockerfile
@@ -10,7 +10,7 @@ ENV HOME /opt/indexer
 WORKDIR /opt/indexer
 
 ENV DEBIAN_FRONTEND noninteractive
-RUN apk add --no-cache git make bash
+RUN apk add --no-cache git make bash build-base
 
 # Copy files to container.
 COPY images/indexer/disabled.go /tmp/disabled.go


### PR DESCRIPTION
Once PQ accounts land (https://github.com/algorand/go-algorand-sdk/pull/825) they will depend on our falcon implementation (https://github.com/algorand/falcon).

This means that go-algorand-sdk usage now requires an cgo-enabled environment.

See https://github.com/algorand/go-algorand-sdk/pull/825#discussion_r3730764547 for more info.